### PR TITLE
Fix bug with false values

### DIFF
--- a/lib/amalgamate/unity.rb
+++ b/lib/amalgamate/unity.rb
@@ -21,7 +21,7 @@ module Amalgamate
       diff_hash = self.diff(master, slave)
       merge_values = diff_hash.reduce({}) do |memo, attribute_set|
         attribute, values = attribute_set
-        memo[attribute] = values[priority] || values[secondary]
+        memo[attribute] = values[priority].nil? ? values[secondary] : values[priority]
         memo
       end
       master.assign_attributes(merge_values)

--- a/spec/dummy/app/models/company.rb
+++ b/spec/dummy/app/models/company.rb
@@ -2,7 +2,7 @@ class Company < ActiveRecord::Base
   has_many :employees, dependent: :destroy
   has_one :headquarter, dependent: :destroy
 
-  attr_accessible :name, :slogan
+  attr_accessible :name, :slogan, :publicly_traded
   validates :name, presence: true
 
 end

--- a/spec/dummy/db/migrate/20130208174748_add_publicly_traded_to_company.rb
+++ b/spec/dummy/db/migrate/20130208174748_add_publicly_traded_to_company.rb
@@ -1,0 +1,5 @@
+class AddPubliclyTradedToCompany < ActiveRecord::Migration
+  def change
+    add_column :companies, :publicly_traded, :boolean
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,13 +11,14 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130208144808) do
+ActiveRecord::Schema.define(:version => 20130208174748) do
 
   create_table "companies", :force => true do |t|
     t.string   "name"
     t.string   "slogan"
-    t.datetime "created_at", :null => false
-    t.datetime "updated_at", :null => false
+    t.datetime "created_at",      :null => false
+    t.datetime "updated_at",      :null => false
+    t.boolean  "publicly_traded"
   end
 
   create_table "employees", :force => true do |t|

--- a/spec/factories/companies.rb
+++ b/spec/factories/companies.rb
@@ -3,6 +3,7 @@ FactoryGirl.define do
   factory :company do
     name { Faker::Company.name }
     slogan { Faker::Company.catch_phrase }
+    publicly_traded { false }
     factory :company_with_headquarter do
       after(:create) do |company|
         FactoryGirl.create(:headquarter, company: company)

--- a/spec/models/amalgamate/unity_spec.rb
+++ b/spec/models/amalgamate/unity_spec.rb
@@ -4,7 +4,6 @@ describe Amalgamate::Unity do
   context "public methods" do
     subject { Amalgamate::Unity.new }
     it { subject.respond_to?(:unify).should be_true }
-    it { subject.respond_to?(:combine).should be_true }
     it { subject.respond_to?(:diff).should be_true }
   end
 


### PR DESCRIPTION
Dan,

I just noticed that there is a bug that occurs when the master has a `false` value for an attribute while the slave has a `true` value.

This is a quick fix to illustrate the problem. The new "does not overwrite false values in master" spec is technically redundant (updating the "uses #assign_attributes to update master" spec catches the problem), but I feel it's a bit clearer IMHO.

Best wishes,
Ben
